### PR TITLE
docs: restructure docs for single source of truth, add .claude/ config

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -1,0 +1,76 @@
+# JSRS — Claude Code Configuration
+
+## Project
+
+JSRS is a Glassdoor alternative with cryptographic anonymity via Zero-Knowledge Proofs.
+
+- Architecture, domain model, key decisions → [docs/architecture.md](../docs/architecture.md)
+- ZKP system → [docs/zkp-system.md](../docs/zkp-system.md)
+- Dev commands → [docs/development.md](../docs/development.md)
+- Commit/branch conventions → [CONTRIBUTING.md](../CONTRIBUTING.md)
+
+---
+
+## GitHub-Driven Workflow
+
+**Every piece of work follows this flow — no exceptions.**
+
+```
+milestone (phase) → issue (task) → branch → PR → squash merge
+```
+
+### Commands
+
+```bash
+# Milestones use the API (gh milestone create does not exist)
+gh api repos/lkaric/jsrs/milestones --method POST -f title="..." -f description="..."
+
+# Issues
+gh issue create --repo lkaric/jsrs --title "..." --milestone "Phase N — ..." --body "..."
+gh issue create --repo lkaric/jsrs --title "..." --label "bug" --body "..."
+
+# PRs
+gh pr create --repo lkaric/jsrs --title "..." --base main --head feat/... --body "..."
+
+# Rebase after upstream merge
+git fetch origin && git rebase origin/main && git push --force-with-lease origin <branch>
+```
+
+### Milestones
+
+| # | Milestone |
+|---|---|
+| 1 | Phase 1 — Scaffold & Auth |
+| 2 | Phase 2 — Job Board |
+| 3 | Phase 3 — ZKP Spike + svc-verify |
+| 4 | Phase 4 — Anonymous Reviews |
+| 5 | Phase 5 — Salary Data |
+| 6 | Phase 6 — Launch Prep |
+
+---
+
+## Domain Boundaries
+
+Three schema domains — **FKs never cross boundaries.**
+
+```
+packages/db/src/schema/
+  auth/   ← better-auth managed (do not hand-edit)
+  jobs/   ← companies, jobs, applications
+  anon/   ← ZKP: merkle trees, nullifiers, reviews, salaries (Phase 3)
+```
+
+`company_id` flows from `anon/` → `jobs/` as a plain value only — never a FK.
+
+---
+
+## Things to Never Do
+
+- Never hand-edit `packages/db/src/schema/auth/` — regenerate with `auth@latest generate`
+- Never add a FK from `anon/` to `auth/` or `jobs/`
+- Never store work emails — OTP uses better-auth `verification` table + `emailDomain` only
+- Never bundle snarkjs statically — always dynamic `import()`
+- Never write raw SQL — use Drizzle schema + migrations
+- Never skip the issue → branch → PR flow
+- Never commit directly to `main`
+- Never enforce gitmoji via commitlint — it is optional (see CONTRIBUTING.md)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(pnpm *)",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(docker *)",
+      "Bash(docker compose *)",
+      "Bash(node *)",
+      "Bash(npx *)",
+      "Bash(turbo *)",
+      "Bash(mkdir *)",
+      "Bash(cp *)",
+      "Bash(mv *)",
+      "Bash(rm *)",
+      "Bash(ls *)",
+      "Bash(cat *)"
+    ],
+    "deny": ["Read(./.env)", "Read(./.env.*)", "Read(./.env.local)", "Read(./secrets/**)"]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# JSRS — Claude Code
+
+Read the following files before starting any work in this repo:
+
+- **[.claude/context.md](.claude/context.md)** — workflow rules, domain boundaries, things to never do
+- **[docs/architecture.md](docs/architecture.md)** — tech stack, schema domains, key decisions
+- **[docs/development.md](docs/development.md)** — local dev commands, env vars, migrations
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — branch naming, commit format, gitmoji reference

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,10 @@
-# Contributing to JSRS
+# 🤝 Contributing to JSRS
 
-Thank you for your interest in contributing! This document covers the development workflow.
+## 🚀 Setup
 
-## Development Setup
+See [docs/development.md](./docs/development.md) for the full local setup guide.
 
-Follow the [Quick Start](./README.md#quick-start) in the README.
-
-## Branch Naming
+## 🌿 Branch Naming
 
 | Type | Pattern | Example |
 |---|---|---|
@@ -15,45 +13,60 @@ Follow the [Quick Start](./README.md#quick-start) in the README.
 | Chore | `chore/description` | `chore/update-deps` |
 | Docs | `docs/description` | `docs/zkp-enrollment-flow` |
 
-## Commit Messages
+## 📝 Commit Messages
 
 We use [Conventional Commits](https://www.conventionalcommits.org/). Enforced by commitlint.
 
-**Format**: `type(optional-scope): description`
+**Format:** `type(optional-scope): description`
 
-**Types**: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `test`, `ci`, `perf`, `revert`
+**Types:** `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `test`, `ci`, `perf`, `revert`
 
-**Examples**:
+### Gitmoji (optional but encouraged ✨)
+
+Prefix your commit with an emoji for extra clarity — not enforced, just fun.
+
+| Emoji | Type | When to use |
+|---|---|---|
+| ✨ | `feat` | New feature |
+| 🐛 | `fix` | Bug fix |
+| 📝 | `docs` | Documentation |
+| 🎨 | `style` | Formatting, no logic change |
+| ♻️ | `refactor` | Refactor without feature/fix |
+| 🧪 | `test` | Tests |
+| 👷 | `ci` | CI/CD changes |
+| 🔧 | `chore` | Build, deps, tooling |
+| ⚡️ | `perf` | Performance |
+| ⏪ | `revert` | Revert a commit |
+| 🔒 | `fix` | Security fix |
+| 🗄️ | `feat` | Database schema |
+| 🔐 | `feat` | Auth / ZKP |
+
+**Examples:**
 ```
-feat(reviews): add ZKP proof generation web worker
-fix(svc-verify): handle merkle root staleness window
-docs(zkp): explain nullifier scoping
+✨ feat(reviews): add ZKP proof generation web worker
+🐛 fix(svc-verify): handle merkle root staleness window
+feat(reviews): add ZKP proof generation web worker   ← also valid
 ```
 
-## Pull Requests
+## 🔀 Pull Requests
 
-- Target `main` branch
-- PR title must follow Conventional Commits format (enforced)
+- Target `main`
+- PR title must follow Conventional Commits format
 - Squash merge only
 
-## Code Style
+## 🎨 Code Style
 
-- **Biome** handles linting + formatting (runs automatically on commit via Lefthook)
-- `strict: true` TypeScript — no `any` in application code
-- Run manually: `pnpm lint:fix`
-
-## ZKP Changes
-
-If modifying anything in `packages/zkp-core/` or `apps/svc-verify/`:
-
-1. Read [docs/contributing-zkp.md](./docs/contributing-zkp.md) first
-2. Never change Poseidon hash input order without updating all three sites: browser WASM, svc-verify Node, circuit constraints
-3. Pin wasm/zkey/package versions together — a mismatch silently breaks proof verification
-4. Add test vectors for any hash computation change
-
-## Testing
+Biome handles linting + formatting automatically on commit (Lefthook pre-commit hook).
 
 ```bash
-pnpm test           # all tests via Turborepo
-pnpm typecheck      # TypeScript strict check across all workspaces
+pnpm lint:fix     # run manually
+pnpm typecheck    # TypeScript strict check
 ```
+
+No `any` in application code. `strict: true` is enforced.
+
+## 🔒 ZKP Changes
+
+Before modifying anything in `packages/zkp-core/` or `apps/svc-verify/`, read [docs/contributing-zkp.md](./docs/contributing-zkp.md).
+
+TL;DR: hash input order must be identical across browser WASM, svc-verify Node, and circuit constraints. A mismatch silently breaks proof verification.

--- a/README.md
+++ b/README.md
@@ -1,72 +1,65 @@
-# JSRS — Anonymous Tech Reviews + Job Board
+# JSRS — Anonymous Tech Reviews + Job Board 🔏
 
 A Glassdoor alternative for the tech industry with **cryptographic anonymity guarantees** using Zero-Knowledge Proofs. Employees verify their employment via work email and submit anonymous reviews and salary data that cannot be linked back to them — not even by the platform operator.
 
 [![CI](https://github.com/lkaric/jsrs/actions/workflows/ci.yml/badge.svg)](https://github.com/lkaric/jsrs/actions/workflows/ci.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](./LICENSE)
 
-## Tech Stack
+## ⚡ Quick Start
 
-| Layer | Technology |
-|---|---|
-| Monorepo | Turborepo + pnpm workspaces |
-| Full-stack app | TanStack Start (SSR + server functions) |
-| Auth | better-auth (Organizations plugin) |
-| ORM | Drizzle ORM |
-| DB | PostgreSQL |
-| ZKP | Semaphore (off-chain) + snarkjs |
-| UI | shadcn/ui + Tailwind CSS v4 |
-| Email | Resend |
-
-## Quick Start
-
-### Prerequisites
-- Node.js >= 24.13.0
-- pnpm >= 9
-- Docker + Docker Compose
-
-### Setup
+**Prerequisites:** Node.js >= 24.13.0, pnpm >= 9, Docker
 
 ```bash
 git clone https://github.com/lkaric/jsrs
 cd jsrs
 pnpm install
-cp .env.example .env.local
-# Edit .env.local with your secrets
+cp .env.example .env.local   # fill in secrets
 docker compose up -d
-pnpm db:generate
-pnpm db:migrate
+pnpm db:generate && pnpm db:migrate
 pnpm dev
 ```
 
-The web app runs at `http://localhost:3000` and svc-verify at `http://localhost:3001`.
+Web app at `http://localhost:3000` — svc-verify at `http://localhost:3001`.
 
-## How Anonymity Works
+For the full setup guide including env vars, troubleshooting, and individual app commands, see [docs/development.md](./docs/development.md).
 
-1. **Enrollment**: User verifies work email → browser generates a cryptographic identity secret → commitment (hash of secret) is added to a company-specific Merkle tree → email mapping is immediately deleted
-2. **Review Submission**: Browser generates a Zero-Knowledge Proof proving membership in the company's Merkle tree without revealing which leaf → server verifies proof via svc-verify → review is stored with no link to user identity
-3. **Double-Submit Prevention**: Nullifier hashes (derived from identity secret + scope) prevent the same identity from submitting twice per company per scope
+## 🔒 How Anonymity Works
 
-See [docs/zkp-system.md](./docs/zkp-system.md) for a detailed explanation.
+1. **Enrollment** — Work email verified via OTP → browser generates cryptographic identity secret → commitment added to company Merkle tree → email mapping immediately deleted
+2. **Proof generation** — Browser generates a ZKP proving Merkle membership without revealing which leaf
+3. **Submission** — Server verifies proof via svc-verify → review stored with zero link to user identity
 
-## Project Structure
+See [docs/zkp-system.md](./docs/zkp-system.md) for a full explanation.
+
+## 📁 Project Structure
 
 ```
 apps/
-  web/          # TanStack Start app (SSR + server functions)
+  web/          # TanStack Start — public site + employer dashboard
   svc-verify/   # Internal Hono service for ZKP verification
 packages/
   db/           # Drizzle schema + migrations
   auth/         # better-auth configuration
   ui/           # shadcn/ui components
   types/        # Shared TypeScript types
-  zkp-core/     # ZKP utilities (commitment, nullifier, proof, merkle)
+  zkp-core/     # ZKP utilities (commitment, nullifier, proof, Merkle)
 ```
 
-## Contributing
+See [docs/architecture.md](./docs/architecture.md) for tech stack, domain model, and key decisions.
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidelines.
+## 📚 Docs
 
-## License
+| Document | What's in it |
+|---|---|
+| [docs/architecture.md](./docs/architecture.md) | Tech stack, schema domains, key decisions |
+| [docs/development.md](./docs/development.md) | Full dev setup, commands, env vars |
+| [docs/zkp-system.md](./docs/zkp-system.md) | ZKP concepts, enrollment + proof flows |
+| [docs/contributing-zkp.md](./docs/contributing-zkp.md) | How to safely modify ZKP code |
+
+## 🤝 Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## 📄 License
 
 GPL-3.0-or-later — see [LICENSE](./LICENSE)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,123 @@
+# 🏗️ Architecture
+
+## What is JSRS?
+
+A Glassdoor alternative for the tech industry with **cryptographic anonymity guarantees** using Zero-Knowledge Proofs. Users prove employment via work email and submit anonymous reviews + salary data that cannot be linked back to them — not even by the platform operator.
+
+---
+
+## Tech Stack
+
+| Layer | Technology | Notes |
+|---|---|---|
+| Monorepo | Turborepo + pnpm workspaces | Single repo, multiple apps + packages |
+| Full-stack app | TanStack Start | SSR + typed server functions |
+| Auth | better-auth | Organizations plugin for employer accounts |
+| ORM | Drizzle ORM | Schema-first, fully typed |
+| DB | PostgreSQL | Docker (local), Neon (production) |
+| ZKP | Semaphore (off-chain) + snarkjs | Browser WASM proof generation |
+| UI | shadcn/ui + Tailwind CSS v4 | |
+| Email | Resend | OTP delivery |
+
+---
+
+## Monorepo Structure
+
+```
+apps/
+  web/                  # TanStack Start — public site + employer dashboard
+  svc-verify/           # Internal Hono service — ZKP verification only
+packages/
+  db/                   # Drizzle schema + migrations (source of truth for DB)
+  auth/                 # better-auth config + client export
+  ui/                   # shadcn/ui component library
+  types/                # Shared TypeScript types
+  zkp-core/             # ZKP utilities: commitment, nullifier, proof, Merkle
+```
+
+---
+
+## Database Schema — Three Domains
+
+The schema is divided into three domains with strict boundary rules. **Foreign keys never cross domain boundaries.**
+
+```
+packages/db/src/schema/
+  auth/    ← Identity: users, sessions, accounts, organizations, members
+  jobs/    ← Job board: companies, jobs, applications
+  anon/    ← ZKP anonymous: merkle_trees, leaves, nullifiers, reviews, salaries
+```
+
+**The one allowed cross-domain reference:** `company_id` (cuid2, text) flows from `anon/` into `jobs/companies.id` — stored as a plain value, **never declared as a FK**.
+
+### auth/ domain
+
+Managed by better-auth — do not hand-edit. Regenerate with:
+```bash
+DATABASE_URL="..." pnpm dlx auth@latest generate \
+  --config ./packages/auth/src/auth.ts \
+  --output ./packages/db/src/schema/auth/index.ts --yes
+```
+
+Tables: `user`, `session`, `account`, `verification`, `organization`, `member`, `invitation`
+
+### jobs/ domain
+
+| Table | Key columns |
+|---|---|
+| `companies` | id (cuid2), organization_id (FK→org), name, slug, verified |
+| `jobs` | id, company_id (FK), title, employment_type, status, salary_min/max |
+| `applications` | id, job_id (FK), user_id (FK), status — UNIQUE(job_id, user_id) |
+
+### anon/ domain
+
+No FKs to any other domain. Built in Phase 3.
+
+| Table | Key columns |
+|---|---|
+| `merkle_trees` | id, company_id (no FK), root (hex), leaf_count |
+| `merkle_leaves` | id, tree_id (FK→trees), commitment (hex), leaf_index |
+| `nullifier_set` | nullifier_hash (PK), scope (review/salary), company_id. **Never deleted.** |
+| `anonymous_reviews` | id, company_id, nullifier_hash (FK→nullifier_set), rating, role_title, pros, cons |
+| `anonymous_salaries` | id, company_id, nullifier_hash (FK→nullifier_set), base_salary, total_comp, level |
+
+---
+
+## Key Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Primary keys | cuid2 (`text`, JS-generated) | URL-safe, no sequential guessing, works offline |
+| OTP storage | better-auth `verification` table | No separate table needed, no `workEmail` stored |
+| Auth schema | better-auth generated | Keeps auth tables in sync with library; do not hand-edit |
+| ZKP proving | Off-chain Semaphore, snarkjs in browser | No blockchain, no gas, sub-3s proof generation target |
+| Merkle trees | Per-company | Isolates membership sets; nullifiers are also per-company |
+| svc-verify | Internal Hono service, HMAC-secured | Never exposed publicly; single writer for tree integrity |
+| Neon (prod) | `neon-serverless` WebSocket adapter | Required for transaction support in serverless environments |
+
+---
+
+## svc-verify API (internal)
+
+All routes are HMAC-secured. Never exposed publicly.
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/enroll` | Insert commitment as Merkle leaf, return new root + leafIndex |
+| POST | `/verify-proof` | Nullifier check + snarkjs groth16.verify |
+| GET | `/merkle-root/:companyId` | Current root + leafCount for client proof generation |
+| GET | `/merkle-proof/:companyId/:leafIndex` | Siblings + pathIndices for client proof generation |
+| GET | `/health` | Health check |
+
+---
+
+## Build Phases
+
+| Phase | Deliverable |
+|---|---|
+| 1 | Scaffold, auth, employer org creation |
+| 2 | Job board (listings, apply, ATS) |
+| 3 | ZKP spike + svc-verify |
+| 4 | Anonymous reviews |
+| 5 | Salary data |
+| 6 | Launch prep (rate limiting, CSP, logging, Neon) |

--- a/docs/contributing-zkp.md
+++ b/docs/contributing-zkp.md
@@ -1,0 +1,82 @@
+# 🧪 Contributing to ZKP Code
+
+The ZKP system is the core privacy guarantee of JSRS. Changes here require extra care — a subtle mismatch silently breaks proof verification or, worse, breaks anonymity.
+
+Read [zkp-system.md](./zkp-system.md) first to understand the system before touching any of this code.
+
+---
+
+## The Three Sites Rule
+
+The Poseidon hash inputs must be **identical** across all three places:
+
+| Site | Location |
+|---|---|
+| Browser WASM (proof gen) | `packages/zkp-core/src/commitment.ts` + Web Worker |
+| svc-verify (Node, proof verify) | `apps/svc-verify/src/services/proof.service.ts` |
+| Circuit constraints | `packages/zkp-core/src/circuits/` (semaphore.wasm + .zkey) |
+
+**If you change hash input order in one place, you must change it in all three.** A mismatch produces a proof that always fails — no error, just silent rejection.
+
+---
+
+## Version Pinning
+
+The circuit artifacts, snarkjs, and `@semaphore-protocol/*` packages must be pinned at **exact matching versions**. Do not upgrade one without upgrading all.
+
+When upgrading:
+1. Download new `semaphore.wasm` + `semaphore.zkey` matching the target version
+2. Update `snarkjs` and `@semaphore-protocol/*` in `packages/zkp-core/package.json`
+3. Re-run test vectors (see below) before opening a PR
+4. Document the version bump in the PR description
+
+---
+
+## Test Vectors
+
+Any change to hash computation (commitment, nullifier, signal) must include test vectors:
+
+```typescript
+// packages/zkp-core/src/__tests__/commitment.test.ts
+it('produces known commitment for known secret', () => {
+  const secret = BigInt('0x1234...'); // fixed test input
+  expect(commitment(secret)).toBe('0xabcd...'); // pre-computed expected output
+});
+```
+
+Test vectors pin the expected output for known inputs. If a refactor accidentally changes the hash output, the test vector fails loudly.
+
+---
+
+## snarkjs Bundle Size
+
+snarkjs WASM is ~5MB. It must **never** be imported statically:
+
+```typescript
+// ✅ correct — loaded on demand in Web Worker only
+const snarkjs = await import('snarkjs');
+
+// ❌ wrong — inflates main bundle
+import snarkjs from 'snarkjs';
+```
+
+The Web Worker entry point is the only place snarkjs is allowed to load.
+
+---
+
+## Merkle Tree Integrity
+
+`svc-verify` is the **single writer** for Merkle trees. Never write to `merkle_leaves` or `merkle_trees` directly from the web app. Always go through `svc-verify POST /enroll`.
+
+On startup, svc-verify rebuilds the in-memory tree from the DB. For large trees this can be slow — the service stores serialized snapshots and replays only newer leaves.
+
+---
+
+## Checklist Before Opening a PR
+
+- [ ] Read the Three Sites Rule and verified all three are consistent
+- [ ] Test vectors pass
+- [ ] snarkjs is loaded via dynamic `import()` only
+- [ ] Circuit artifact versions are pinned and match snarkjs
+- [ ] `nullifier_set` insert is atomic with the review/salary insert (transaction)
+- [ ] No new FK added from `anon/` to `auth/` or `jobs/`

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,110 @@
+# 🛠️ Development Guide
+
+## Prerequisites
+
+- **Node.js** >= 24.13.0 (use `.node-version` with fnm/nvm)
+- **pnpm** >= 9
+- **Docker** + Docker Compose
+
+## First-Time Setup
+
+```bash
+git clone https://github.com/lkaric/jsrs
+cd jsrs
+pnpm install
+cp .env.example .env.local
+```
+
+Edit `.env.local` — every variable is documented in `.env.example`.
+
+## Starting the Database
+
+```bash
+docker compose up -d          # starts Postgres 16 on localhost:5432
+docker compose logs -f db     # tail logs
+docker compose down           # stop
+```
+
+## Database Migrations
+
+```bash
+# Generate a new migration after schema changes
+DATABASE_URL="postgresql://..." pnpm db:generate
+
+# Apply pending migrations
+DATABASE_URL="postgresql://..." pnpm db:migrate
+
+# Open Drizzle Studio (visual DB browser)
+DATABASE_URL="postgresql://..." pnpm db:studio
+```
+
+## Regenerating the better-auth Schema
+
+After changing `packages/auth/src/auth.ts` (e.g. adding a plugin):
+
+```bash
+DATABASE_URL="postgresql://..." pnpm dlx auth@latest generate \
+  --config ./packages/auth/src/auth.ts \
+  --output ./packages/db/src/schema/auth/index.ts \
+  --yes
+```
+
+The output file is managed by better-auth — do not hand-edit it.
+
+## Running the Apps
+
+```bash
+pnpm dev          # starts web (port 3000) + svc-verify (port 3001) via Turborepo
+```
+
+Or run individually:
+```bash
+pnpm --filter @jsrs/web dev
+pnpm --filter @jsrs/svc-verify dev
+```
+
+## Linting & Formatting
+
+```bash
+pnpm lint         # Biome check (read-only)
+pnpm lint:fix     # Biome check + auto-fix (runs on commit via Lefthook)
+```
+
+## Type Checking
+
+```bash
+pnpm typecheck    # tsc --noEmit across all workspaces (runs on push via Lefthook)
+```
+
+## Building
+
+```bash
+pnpm build        # build all apps + packages via Turborepo
+```
+
+## Environment Variables
+
+All variables are documented in `.env.example`. Key groups:
+
+| Variable | Required for |
+|---|---|
+| `DATABASE_URL` | All DB operations |
+| `BETTER_AUTH_SECRET` | Session signing |
+| `BETTER_AUTH_URL` | OAuth callback base URL |
+| `GITHUB_CLIENT_ID/SECRET` | GitHub OAuth |
+| `GOOGLE_CLIENT_ID/SECRET` | Google OAuth |
+| `RESEND_API_KEY` | OTP email delivery |
+| `SVC_VERIFY_URL` | Web app → svc-verify |
+| `SVC_VERIFY_HMAC_SECRET` | HMAC auth between web + svc-verify |
+
+## Dev Container
+
+A `.devcontainer/devcontainer.json` is provided for VS Code / GitHub Codespaces. It includes Docker-in-Docker so `docker compose up -d` works out of the box.
+
+## Troubleshooting
+
+**`DATABASE_URL` not picked up** — prefix the command directly: `DATABASE_URL="..." pnpm db:migrate`
+
+**Port conflicts** — web defaults to 3000, svc-verify to 3001. Set `PORT` in `.env.local` to override.
+
+**pnpm install fails** — ensure Node.js >= 24.13.0 (`node -v`). Use fnm: `fnm use`.

--- a/docs/zkp-system.md
+++ b/docs/zkp-system.md
@@ -1,0 +1,126 @@
+# 🔒 ZKP System
+
+JSRS uses **off-chain Semaphore** (snarkjs + Groth16) to let verified employees submit anonymous reviews and salary data with cryptographic guarantees — no blockchain required.
+
+---
+
+## Core Concepts
+
+### Identity Secret & Commitment
+
+When a user first enrolls for a company:
+
+1. The **browser** generates a random `identitySecret` (256-bit random scalar)
+2. The browser computes `commitment = Poseidon(identitySecret)` — a one-way hash
+3. The `commitment` is sent to the server and stored as a Merkle leaf
+4. The `identitySecret` is stored in **localStorage**, namespaced by `companyId`
+5. The email-to-commitment mapping is **deleted immediately** after enrollment — the DB cannot link commitments to users
+
+The commitment proves group membership without revealing who you are.
+
+### Per-Company Merkle Trees
+
+Each company has its own Merkle tree of verified employee commitments. The tree depth is 20 (supports ~1M members).
+
+When a new commitment is enrolled:
+- It is inserted as a new leaf
+- The Merkle root is updated
+- The new root is stored in `merkle_trees`
+
+### Nullifier Hashes
+
+To prevent double-submissions without tracking identity:
+
+```
+nullifierHash = Poseidon(Poseidon(identitySecret), Poseidon(companyId, scope))
+```
+
+Where `scope` is `"review"` or `"salary"`. This means:
+- Each identity can submit **one review** per company
+- Each identity can submit **one salary** per company
+- Review and salary nullifiers are independent — both can be submitted
+- Nullifiers across companies are unlinkable (different `companyId`)
+
+Nullifiers are stored in `nullifier_set` and **never deleted**. A second submission with the same nullifier is rejected.
+
+### Zero-Knowledge Proof
+
+The user generates a ZKP proving:
+> *"I know an `identitySecret` such that `Poseidon(identitySecret)` is a leaf in the Merkle tree with root R, and my nullifier for this scope is N"* — **without revealing which leaf**.
+
+The proof is generated in the browser via snarkjs in a **Web Worker** (keeps UI responsive). Target: < 3 seconds.
+
+---
+
+## Enrollment Flow
+
+```
+1. Browser generates identitySecret, computes commitment = Poseidon(identitySecret)
+   └─ stores { identitySecret, leafIndex } in localStorage[companyId]
+
+2. User submits work email
+   └─ server validates email domain → sends OTP via Resend
+   └─ OTP stored in better-auth verification table (NOT linked to commitment)
+
+3. User submits OTP
+   └─ server verifies OTP → calls svc-verify POST /enroll { commitment, companyId }
+   └─ svc-verify inserts leaf, updates Merkle root, returns { root, leafIndex }
+   └─ server DELETES the verification record (email domain gone)
+   └─ leafIndex returned to browser → stored in localStorage
+
+4. Enrollment complete — no DB record links the user to their commitment
+```
+
+---
+
+## Proof Submission Flow
+
+```
+1. Browser fetches { root, siblings, pathIndices }
+   └─ server function → svc-verify GET /merkle-root/:companyId
+   └─ server function → svc-verify GET /merkle-proof/:companyId/:leafIndex
+
+2. Browser computes nullifierHash = Poseidon(Poseidon(secret), Poseidon(companyId, scope))
+
+3. Browser generates ZKP via snarkjs in Web Worker
+   └─ inputs: identitySecret, siblings, pathIndices, root, nullifierHash, signal
+   └─ circuit: semaphore.wasm + semaphore.zkey (pinned versions in packages/zkp-core)
+
+4. Browser POSTs { proof, publicSignals, nullifierHash, content } to server function
+
+5. Server recomputes signal = hash(content), confirms it matches publicSignals[signalIndex]
+
+6. Server calls svc-verify POST /verify-proof
+   └─ nullifier check (not in nullifier_set)
+   └─ Merkle root check (in recent root window)
+   └─ snarkjs groth16.verify
+
+7. On success: INSERT anonymous_reviews (or anonymous_salaries), return success
+```
+
+---
+
+## Root Staleness
+
+New enrollments between the time a user fetches the Merkle proof and submits would invalidate the root. svc-verify accepts a **sliding window of the last N roots** per company so in-flight proofs remain valid.
+
+---
+
+## Security Properties
+
+| Property | How it's achieved |
+|---|---|
+| Anonymity | ZKP proves membership without revealing leaf index |
+| Unlinkability | Poseidon nullifier uses `companyId` — cross-company correlation impossible |
+| Double-submit prevention | `nullifier_set` checked atomically before insert |
+| No email → review link | `verification` record deleted on enrollment |
+| No operator deanonymization | `identitySecret` never leaves the browser |
+| snarkjs isolation | Loaded via dynamic `import()` only, never statically bundled |
+
+---
+
+## Circuit Artifacts
+
+The Semaphore circuit artifacts (`semaphore.wasm`, `semaphore.zkey`) live in `packages/zkp-core/src/circuits/` and are **gitignored**. They must be pinned at exact versions matching the snarkjs and `@semaphore-protocol` package versions.
+
+See [contributing-zkp.md](./contributing-zkp.md) before touching anything in `packages/zkp-core/`.


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` at repo root — auto-loaded by Claude Code, instructs it to read `.claude/context.md` and `docs/`
- Add `.claude/context.md` — workflow rules, domain boundaries, things to never do
- Add `.claude/settings.json` — project-level permission allow/deny rules
- Create `docs/` with four canonical reference documents:
  - `architecture.md` — tech stack, schema domains, key decisions
  - `development.md` — full dev setup, commands, env vars, troubleshooting
  - `zkp-system.md` — ZKP concepts, enrollment and proof submission flows
  - `contributing-zkp.md` — three sites rule, version pinning, safety checklist
- Slim down `README.md` to entry point with doc links
- Update `CONTRIBUTING.md` to own workflow conventions only; add gitmoji reference table (optional, not enforced)

Each topic now has exactly one home. Everything else links to it.

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/claude-code)