### PR TITLE
fix(cd): deploy web independently and configure js.rs domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
   deploy-web:
     name: Deploy web
     runs-on: ubuntu-latest
-    needs: deploy-svc-verify
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -3,6 +3,9 @@ main = "@tanstack/react-start/server-entry"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
+[[custom_domains]]
+pattern = "js.rs"
+
 [[services]]
 binding = "SVC_VERIFY"
 service = "jsrs-svc-verify"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,6 +79,9 @@ main = "@tanstack/react-start/server-entry"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
+[[custom_domains]]
+pattern = "js.rs"
+
 [[services]]
 binding = "SVC_VERIFY"
 service = "jsrs-svc-verify"
@@ -138,7 +141,6 @@ Worker secrets are set per-Worker. Run `wrangler secret put <NAME>` from the res
 Deploy from local (requires `wrangler login`):
 
 ```bash
-# Always deploy svc-verify first — web depends on it via service binding
 cd apps/svc-verify && wrangler deploy
 cd apps/web && wrangler deploy
 ```
@@ -151,7 +153,7 @@ Deployment is automated via `.github/workflows/deploy.yml`.
 
 **Trigger:** `workflow_run` on the `CI` workflow completing successfully on `main`. This means deploys only happen after lint + typecheck + build pass.
 
-**Order:** `deploy-svc-verify` runs first. `deploy-web` has `needs: deploy-svc-verify` — it only starts after `svc-verify` is live. This prevents a window where `web` is deployed with a stale or missing service binding target.
+**Jobs:** `deploy-svc-verify` and `deploy-web` run in **parallel** — both are gated only on CI success via `if: github.event.workflow_run.conclusion == 'success'`. Neither job depends on the other.
 
 **Concurrency:** `cancel-in-progress: false` — deploys are never cancelled mid-flight.
 
@@ -178,6 +180,6 @@ After initial setup:
 1. Merge a PR to `main`
 2. Confirm CI workflow completes — check the **Actions** tab
 3. Confirm Deploy workflow triggers via `workflow_run` (appears as a separate run)
-4. **Expected:** `deploy-svc-verify` fails with "no wrangler.toml found" — `apps/svc-verify` not yet scaffolded (Phase 3). `deploy-web` never runs since it `needs: deploy-svc-verify`. Confirm the failure is a missing file, not a Wrangler auth error.
+4. **Expected:** `deploy-svc-verify` fails with "no wrangler.toml found" — `apps/svc-verify` not yet scaffolded (Phase 3). `deploy-web` runs in parallel and should succeed. Confirm the svc-verify failure is a missing file, not a Wrangler auth error.
 5. When `apps/svc-verify` is scaffolded (Phase 3): add `wrangler.toml` → both jobs should pass
 6. End-to-end: push a change to `main` → confirm both Workers updated in Cloudflare dashboard


### PR DESCRIPTION
## Summary

- Remove `needs: deploy-svc-verify` from `deploy-web` — both jobs now run in parallel, each gated only on CI success via `if:`
- Add `apps/web/wrangler.toml` with `[[custom_domains]]` pattern = `js.rs`
- Update `docs/deployment.md` to reflect parallel deployment and domain config

## What was wrong

`deploy-web` had `needs: deploy-svc-verify`, so it never ran since `svc-verify` has no `wrangler.toml` yet (Phase 3). Web was perpetually blocked.

## Test plan

- [ ] Merge to main, confirm Deploy workflow triggers in Actions tab
- [ ] Confirm `deploy-svc-verify` fails gracefully (no wrangler.toml — expected until Phase 3)
- [ ] Confirm `deploy-web` runs **in parallel** and succeeds
- [ ] Confirm both jobs have the same start timestamp in Actions UI
- [ ] Confirm `jsrs-web` appears in Cloudflare Workers dashboard with `js.rs` as custom domain

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)