### PR TITLE
fix(cd): rename github oauth secrets to avoid reserved prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,8 @@ BETTER_AUTH_SECRET="replace-with-32-byte-secret"
 BETTER_AUTH_URL="http://localhost:3000"
 
 # ── OAuth — GitHub ────────────────────────────────────────────
-GITHUB_CLIENT_ID=""
-GITHUB_CLIENT_SECRET=""
+GH_CLIENT_ID=""
+GH_CLIENT_SECRET=""
 
 # ── OAuth — Google ────────────────────────────────────────────
 GOOGLE_CLIENT_ID=""

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,8 +60,8 @@ jobs:
             DATABASE_URL
             BETTER_AUTH_SECRET
             BETTER_AUTH_URL
-            GITHUB_CLIENT_ID
-            GITHUB_CLIENT_SECRET
+            GH_CLIENT_ID
+            GH_CLIENT_SECRET
             GOOGLE_CLIENT_ID
             GOOGLE_CLIENT_SECRET
             RESEND_API_KEY
@@ -70,8 +70,8 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
           BETTER_AUTH_URL: ${{ secrets.BETTER_AUTH_URL }}
-          GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,8 +105,8 @@ Set these in **Settings → Secrets and variables → Actions**:
 | `DATABASE_URL` | Both | Neon PostgreSQL connection string |
 | `BETTER_AUTH_SECRET` | Both | Random 32-byte secret for better-auth session signing |
 | `BETTER_AUTH_URL` | web | Public base URL, e.g. `https://jsrs.app` — used for OAuth callbacks |
-| `GITHUB_CLIENT_ID` | web | GitHub OAuth app client ID |
-| `GITHUB_CLIENT_SECRET` | web | GitHub OAuth app client secret |
+| `GH_CLIENT_ID` | web | GitHub OAuth app client ID |
+| `GH_CLIENT_SECRET` | web | GitHub OAuth app client secret |
 | `GOOGLE_CLIENT_ID` | web | Google OAuth client ID |
 | `GOOGLE_CLIENT_SECRET` | web | Google OAuth client secret |
 | `RESEND_API_KEY` | web | Resend API key for OTP email delivery |
@@ -124,8 +124,8 @@ Local `.env.local` → Cloudflare Worker secrets:
 DATABASE_URL          → wrangler secret put DATABASE_URL
 BETTER_AUTH_SECRET    → wrangler secret put BETTER_AUTH_SECRET
 BETTER_AUTH_URL       → wrangler secret put BETTER_AUTH_URL
-GITHUB_CLIENT_ID      → wrangler secret put GITHUB_CLIENT_ID
-GITHUB_CLIENT_SECRET  → wrangler secret put GITHUB_CLIENT_SECRET
+GH_CLIENT_ID      → wrangler secret put GH_CLIENT_ID
+GH_CLIENT_SECRET  → wrangler secret put GH_CLIENT_SECRET
 GOOGLE_CLIENT_ID      → wrangler secret put GOOGLE_CLIENT_ID
 GOOGLE_CLIENT_SECRET  → wrangler secret put GOOGLE_CLIENT_SECRET
 RESEND_API_KEY        → wrangler secret put RESEND_API_KEY

--- a/docs/development.md
+++ b/docs/development.md
@@ -91,7 +91,7 @@ All variables are documented in `.env.example`. Key groups:
 | `DATABASE_URL` | All DB operations |
 | `BETTER_AUTH_SECRET` | Session signing |
 | `BETTER_AUTH_URL` | OAuth callback base URL |
-| `GITHUB_CLIENT_ID/SECRET` | GitHub OAuth |
+| `GH_CLIENT_ID/SECRET` | GitHub OAuth |
 | `GOOGLE_CLIENT_ID/SECRET` | Google OAuth |
 | `RESEND_API_KEY` | OTP email delivery |
 

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -12,8 +12,8 @@ export const auth = betterAuth({
   },
   socialProviders: {
     github: {
-      clientId: process.env.GITHUB_CLIENT_ID ?? '',
-      clientSecret: process.env.GITHUB_CLIENT_SECRET ?? '',
+      clientId: process.env.GH_CLIENT_ID ?? '',
+      clientSecret: process.env.GH_CLIENT_SECRET ?? '',
     },
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID ?? '',


### PR DESCRIPTION
## Summary

- GitHub Actions reserves the `GITHUB_` prefix for built-in secrets — custom secrets with that prefix are silently rejected
- Rename `GITHUB_CLIENT_ID` → `GH_CLIENT_ID` and `GITHUB_CLIENT_SECRET` → `GH_CLIENT_SECRET` across `deploy.yml`, `auth.ts`, `.env.example`, and docs

## Action required

Add two secrets in **Settings → Secrets and variables → Actions**:
- `GH_CLIENT_ID`
- `GH_CLIENT_SECRET`

And update your local `.env.local` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)