### PR TITLE
fix(cd): add web build step and fix custom domain wrangler config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @jsrs/web build
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -3,8 +3,9 @@ main = "@tanstack/react-start/server-entry"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
-[[custom_domains]]
+[[routes]]
 pattern = "js.rs"
+custom_domain = true
 
 [[services]]
 binding = "SVC_VERIFY"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,8 +79,9 @@ main = "@tanstack/react-start/server-entry"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]
 
-[[custom_domains]]
+[[routes]]
 pattern = "js.rs"
+custom_domain = true
 
 [[services]]
 binding = "SVC_VERIFY"


### PR DESCRIPTION
## Summary

- Add `pnpm --filter @jsrs/web build` before `wrangler deploy` in `deploy-web` — `@tanstack/react-start/server-entry` is a virtual module resolved by `@cloudflare/vite-plugin` during the Vite build, Wrangler can't find it without a prior build
- Replace `[[custom_domains]]` with `[[routes]] custom_domain = true` — `[[custom_domains]]` is not a valid top-level field in Wrangler v3/v4 (was causing a warning and likely ignored)

## Test plan

- [ ] Merge, confirm `deploy-web` passes in Actions
- [ ] Confirm `js.rs` appears as a custom domain in the Cloudflare Workers dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)