### PR TITLE
fix(web): remove svc-verify service binding until phase 3

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -7,9 +7,5 @@ compatibility_flags = ["nodejs_compat"]
 pattern = "js.rs"
 custom_domain = true
 
-[[services]]
-binding = "SVC_VERIFY"
-service = "jsrs-svc-verify"
-
 [observability]
 enabled = true


### PR DESCRIPTION
## Summary

- Cloudflare validates service bindings at deploy time — `jsrs-svc-verify` doesn't exist yet so every `deploy-web` run fails with error 10143
- Remove `[[services]]` binding from `apps/web/wrangler.toml` for now; it will be restored when `svc-verify` is scaffolded in Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)